### PR TITLE
Return afterInstall promise & explicitly import moment.js

### DIFF
--- a/addon/components/baremetrics-calendar.js
+++ b/addon/components/baremetrics-calendar.js
@@ -205,6 +205,8 @@ export default Ember.Component.extend({
     let component = this;
     let config = {
       element: this.$(),
+      earliest_date: this.get('earliestDate'),
+      latest_date: this.get('latestDate'),
       format: {
         input: this.get('inputFormat'),
         jump_month: this.get('jumpMonthFormat'),
@@ -219,9 +221,8 @@ export default Ember.Component.extend({
     if (this.get('type') === 'single') {
       config.current_date = this.get('currentDate');
       config.required = this.get('required');
+      config.placeholder = this.get('placeholder');
     } else {
-      config.earliest_date = this.get('earliestDate');
-      config.latest_date = this.get('latestDate');
       config.start_date = this.get('startDate');
       config.end_date = this.get('endDate');
       config.format.preset = this.get('presetFormat');

--- a/blueprints/ember-baremetrics-calendar/index.js
+++ b/blueprints/ember-baremetrics-calendar/index.js
@@ -3,6 +3,6 @@ module.exports = {
   description: 'Add baremetrics-calendar dependencies',
   normalizeEntityName: function() {},
   afterInstall: function() {
-    this.addBowerPackageToProject('BaremetricsCalendar');
+    return this.addBowerPackageToProject('BaremetricsCalendar');
   }
 };

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ module.exports = {
 
     var isFastBoot = process.env.EMBER_CLI_FASTBOOT === 'true';
     if (!isFastBoot) {
+      app.import('bower_components/moment/moment.js');
       app.import('bower_components/BaremetricsCalendar/public/js/Calendar.js');
     }
     if (options.includeStyles !== false) {


### PR DESCRIPTION
Two patches here:
1. The afterInstall hook will wait for a promise to run before moving on. Without the `return`, the BaremetricsCalendar Bower package was being skipped. 
2. Since the 'Calendar' class requires a `moment`global present, loading the class fails. Explicitly importing `moment.js` prior to loading `Calendar` correct the issue. This _could_ be a problem. If someone uses a version of moment prior to 2.10.0, the path to `moment.js` is different. Also, if someone is using [ember-moment](https://github.com/stefanpenner/ember-moment), there may be two versions of `moment` floating around. ¯_(ツ)_/¯ I don't know the answer to this. Maybe you can provide some insight?
