### PR TITLE
Prepare for ember-cli-fastboot 1.0 release

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,10 @@
 /* jshint node: true */
 'use strict';
+const fs = require('fs');
+
+const Funnel = require('broccoli-funnel');
+const map = require('broccoli-stew').map;
+const mergeTrees = require('broccoli-merge-trees');
 
 module.exports = {
   name: 'ember-baremetrics-calendar',
@@ -14,15 +19,27 @@ module.exports = {
 
     var options = app.options.baremetricsCalendar || {};
 
-    var isFastBoot = process.env.EMBER_CLI_FASTBOOT === 'true';
-    if (!isFastBoot) {
-      app.import('bower_components/BaremetricsCalendar/public/js/Calendar.js');
-    }
+    app.import('vendor/Calendar.js');
+
     if (options.includeStyles !== false) {
       app.import('bower_components/BaremetricsCalendar/public/css/application.css');
     }
 
     return app;
+  },
+  treeForVendor: function(defaultTree) {
+    const app = this._findHost();
+    const assetPath =__dirname + '/' + app.bowerDirectory + '/BaremetricsCalendar/public/js/';
+
+    if (fs.existsSync(assetPath)) {
+      let calendarJs = new Funnel(assetPath, {
+        files: ['Calendar.js']});
+      calendarJs = map(calendarJs,
+        (content) => `if (typeof FastBoot === 'undefined') { ${content} }`);
+      return new mergeTrees([defaultTree, calendarJs]);
+    } else {
+      return defaultTree;
+    }
   }
 
 };

--- a/package.json
+++ b/package.json
@@ -26,8 +26,11 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
+    "broccoli-funnel": "^1.2.0",
+    "broccoli-merge-trees": "^2.0.0",
+    "broccoli-stew": "^1.5.0",
     "ember-ajax": "0.7.1",
-    "ember-cli": "2.5.0",
+    "ember-cli": "2.14.0-beta.2",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-htmlbars": "^1.0.3",


### PR DESCRIPTION
Hi there, ember-cli-fastboot 1.0 will have backwards incompatible changes. Please see doc here https://gist.github.com/kratiahuja/d22de0fb1660cf0ef58f07a6bcbf1a1c. The motivation for this change is documented here ember-fastboot/ember-cli-fastboot#387
The environment variable EMBER_CLI_FASTBOOTdoesn't exists any more in ember-cli-fastboot 1.0 build. I made the changes here, however 5  tests for this repo are already failing without my change. I have verified the build works with ember-cli-fastboot 1.0  I don't have enough context to fix your unit tests. Could you please verify on your side with proper use cases?